### PR TITLE
Update prettier and fine-tune it a bit

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+printWidth: 100
+tabWidth: 4
+trailingComma: es5
+semi: true
+arrowParens: always
+quoteProps: consistent

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,30 +1,32 @@
 {
-  "name": "plop-prettier",
-  "version": "2.0.0",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "@types/node": {
-      "version": "8.10.54",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.54.tgz",
-      "integrity": "sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg==",
-      "dev": true
-    },
-    "@types/prettier": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.18.3.tgz",
-      "integrity": "sha512-48rnerQdcZ26odp+HOvDGX8IcUkYOCuMc2BodWYTe956MqkHlOGAG4oFQ83cjZ0a4GAgj7mb4GUClxYd2Hlodg=="
-    },
-    "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw=="
-    },
-    "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
-      "dev": true
+    "name": "plop-prettier",
+    "version": "2.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@types/node": {
+            "version": "8.10.54",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.54.tgz",
+            "integrity": "sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg==",
+            "dev": true
+        },
+        "@types/prettier": {
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.18.3.tgz",
+            "integrity": "sha512-48rnerQdcZ26odp+HOvDGX8IcUkYOCuMc2BodWYTe956MqkHlOGAG4oFQ83cjZ0a4GAgj7mb4GUClxYd2Hlodg==",
+            "dev": true
+        },
+        "prettier": {
+            "version": "1.18.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+            "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+            "dev": true
+        },
+        "typescript": {
+            "version": "3.6.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+            "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+            "dev": true
+        }
     }
-  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,37 +1,29 @@
 {
   "name": "plop-prettier",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/babel-types": {
-      "version": "6.25.1",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.1.tgz",
-      "integrity": "sha512-7Z6r20+HE0viAFhsW0d/UrC1K2tTlpXzGpNlYm8MmCv8z5PbAacFIshrM/MjlGRa5SBqxu2socpy8FHntwZKng=="
-    },
     "@types/node": {
-      "version": "8.0.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.27.tgz",
-      "integrity": "sha512-MiOd5TB6ftlOw6gLY3XdF0s/9YoTo172A6qGzi5I1SJy2dRZqg/LAHGTJMm1XFWx7kuYkbVW0sp/z3OP7VnkjQ==",
+      "version": "8.10.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.54.tgz",
+      "integrity": "sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg==",
       "dev": true
     },
     "@types/prettier": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.6.1.tgz",
-      "integrity": "sha512-K7Velxb9hB3D4ewRc4dGsNFpe1kf6T9NvGBBv68UGMY5ytAs99sUlyNd9YsfL0IVxRsVFwwv66t4UVVdpBEEXg==",
-      "requires": {
-        "@types/babel-types": "6.25.1"
-      }
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.18.3.tgz",
+      "integrity": "sha512-48rnerQdcZ26odp+HOvDGX8IcUkYOCuMc2BodWYTe956MqkHlOGAG4oFQ83cjZ0a4GAgj7mb4GUClxYd2Hlodg=="
     },
     "prettier": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.6.1.tgz",
-      "integrity": "sha512-f85qBoQiqiFM/sCmJaN4Lagj9bqMcv38vCftqp4GfVessAqq3Ns6g+3gd8UXReStLLE/DGEdwiZXoFKxphKqwg=="
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw=="
     },
     "typescript": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
-      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ=",
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
         "type": "git",
         "url": "git+https://github.com/alsiola/plop-prettier.git"
     },
-    "keywords": ["plop", "prettier"],
+    "keywords": [
+        "plop",
+        "prettier"
+    ],
     "author": "Alex Young",
     "license": "MIT",
     "bugs": {
@@ -22,11 +25,13 @@
     },
     "homepage": "https://github.com/alsiola/plop-prettier#readme",
     "devDependencies": {
-        "@types/node": "^8.0.27",
-        "typescript": "^2.5.2"
+        "@types/node": "^8.10.54",
+        "@types/prettier": "^1.18.3",
+        "prettier": "^1.17.0",
+        "typescript": "^3.6.4"
     },
-    "dependencies": {
-        "@types/prettier": "^1.6.1",
-        "prettier": "^1.6.1"
+    "peerDependencies": {
+        "@types/prettier": "^1.18.3",
+        "prettier": "^1.17.0"
     }
 }


### PR DESCRIPTION
I moved Prettier from deps to peerDeps and devDeps. Everyone who wants to use plop-prettier should take care of adding Prettier themselves. That way someone who uses plop-prettier does not end up having an outdated version or even worse, a conflicting version of Prettier in their project.

I also added a prettier config to the project itself and upgraded TypeScript to 3.x. I hope that was okay.

This one fixes #3 as it was not entirely correct what I said in that ticket: prettierrc is already taken into consideration, the option I used in my prettierrc just wasn't supported in Prettier 1.6 that comes by default with this package.